### PR TITLE
Update rack-cors to at least 1.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'mimemagic',           '~> 0.3.3'
 gem 'more_core_extensions'
 gem 'pg',                  '~> 1.0', :require => false
 gem 'puma',                '~> 3.0'
-gem 'rack-cors',           '>= 0.4.1'
+gem 'rack-cors',           '>= 1.0.4', '~> 1.0'
 gem 'rails',               '>= 5.2.2.1', '~> 5.2.2'
 
 gem 'inventory_refresh',          :git => 'https://github.com/ManageIQ/inventory_refresh',          :branch => 'master'


### PR DESCRIPTION
Fixes a hakiri security warning about file access