### PR TITLE
Enabling the sort_by parameter

### DIFF
--- a/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/app/controllers/api/v1/mixins/index_mixin.rb
@@ -4,11 +4,12 @@ module Api
       module IndexMixin
         def index
           raise_unless_primary_instance_exists
-          render json: Insights::API::Common::PaginatedResponse.new(
-            base_query: scoped(filtered.where(params_for_list)),
-            request: request,
-            limit: pagination_limit,
-            offset: pagination_offset
+          render :json => Insights::API::Common::PaginatedResponse.new(
+            :base_query => scoped(filtered.where(params_for_list)),
+            :request    => request,
+            :limit      => pagination_limit,
+            :offset     => pagination_offset,
+            :sort_by    => query_sort_by
           ).response
         end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,11 +53,11 @@ class ApplicationController < ActionController::API
 
   def safe_params_for_list
     # :limit & :offset can be passed in for pagination purposes, but shouldn't show up as params for filtering purposes
-    @safe_params_for_list ||= params.merge(params_for_polymorphic_subcollection).permit(*permitted_params, :filter => {})
+    @safe_params_for_list ||= params.merge(params_for_polymorphic_subcollection).permit(*permitted_params, :filter => {}, :sort_by => [])
   end
 
   def permitted_params
-    api_doc_definition.all_attributes + [:limit, :offset] + [subcollection_foreign_key]
+    api_doc_definition.all_attributes + [:limit, :offset, :sort_by] + [subcollection_foreign_key]
   end
 
   def subcollection_foreign_key
@@ -126,6 +126,10 @@ class ApplicationController < ActionController::API
 
   def pagination_offset
     safe_params_for_list[:offset]
+  end
+
+  def query_sort_by
+    safe_params_for_list[:sort_by]
   end
 
   def params_for_update

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -104,6 +104,28 @@ RSpec.describe("::Insights::API::Common::Filter") do
     it("key:not_nil")        { expect_success("filter[completed_at][not_nil]", task_2, task_3, task_4) }
   end
 
+  context "sorted results via sort_by" do
+    before do
+      source = Source.create!(:tenant => tenant)
+      Vm.create!(:name => "sort_by_vm_a", :source => source, :tenant => tenant, :source_ref => "vm_a")
+      Vm.create!(:name => "sort_by_vm_b", :source => source, :tenant => tenant, :source_ref => "vm_b")
+    end
+
+    it "available for vms with default order" do
+      get("/api/v1.0/vms?filter[name][starts_with]=sort_by_vm&sort_by=name", :headers => headers)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"].collect { |vm| vm["name"] }).to eq(%w[sort_by_vm_a sort_by_vm_b])
+    end
+
+    it "available for vms with desc order" do
+      get("/api/v1.0/vms?filter[name][starts_with]=sort_by_vm&sort_by=name:desc", :headers => headers)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"].collect { |vm| vm["name"] }).to eq(%w[sort_by_vm_b sort_by_vm_a])
+    end
+  end
+
   context "error cases" do
     it("empty filter")      { expect_failure("filter", "ActionController::UnpermittedParameters: found unpermitted parameter: :filter") }
     it("unknown attribute") { expect_failure("filter[xxx]", "Insights::API::Common::Filter::Error: found unpermitted parameter: xxx") }

--- a/spec/requests/api/v2.0/filter_spec.rb
+++ b/spec/requests/api/v2.0/filter_spec.rb
@@ -104,6 +104,28 @@ RSpec.describe("::Insights::API::Common::Filter") do
     it("key:not_nil")        { expect_success("filter[completed_at][not_nil]", task_2, task_3, task_4) }
   end
 
+  context "sorted results via sort_by" do
+    before do
+      source = Source.create!(:tenant => tenant)
+      Vm.create!(:name => "sort_by_vm_a", :source => source, :tenant => tenant, :source_ref => "vm_a")
+      Vm.create!(:name => "sort_by_vm_b", :source => source, :tenant => tenant, :source_ref => "vm_b")
+    end
+
+    it "available for vms with default order" do
+      get("/api/v2.0/vms?filter[name][starts_with]=sort_by_vm&sort_by=name", :headers => headers)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"].collect { |vm| vm["name"] }).to eq(%w[sort_by_vm_a sort_by_vm_b])
+    end
+
+    it "available for vms with desc order" do
+      get("/api/v2.0/vms?filter[name][starts_with]=sort_by_vm&sort_by=name:desc", :headers => headers)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"].collect { |vm| vm["name"] }).to eq(%w[sort_by_vm_b sort_by_vm_a])
+    end
+  end
+
   context "error cases" do
     it("empty filter")      { expect_failure("filter", "ActionController::UnpermittedParameters: found unpermitted parameter: :filter") }
     it("unknown attribute") { expect_failure("filter[xxx]", "Insights::API::Common::Filter::Error: found unpermitted parameter: xxx") }


### PR DESCRIPTION
Enabling the sort_by parameter, was only exposed via graphql for all, for rest, only the common dummy app in common had it exposed.  

Added a small spec to verify it is now exposed here, the comprehensive tests for sort_by is in common.

Fixes: TPINVTRY-801