### PR TITLE
Internal API doesn't allow validation against openapi.json

### DIFF
--- a/app/controllers/internal/v1/sources_controller.rb
+++ b/app/controllers/internal/v1/sources_controller.rb
@@ -1,6 +1,8 @@
 module Internal
   module V1
     class SourcesController < ::ApplicationController
+      skip_before_action(:validate_request) # Doesn't validate against openapi.json
+
       include Api::V1::Mixins::UpdateMixin
     end
   end


### PR DESCRIPTION
OpenAPI.json doesn't contain internal API paths, so updating of `Source.refresh_status` returned 400 Bad Request error.