### PR TITLE
Added x-rh-identity to Kafka's event Task.update

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -7,11 +7,14 @@ module Api
       def update
         model.update(params.require(:id), params_for_update)
 
-        messaging_client.publish_topic(
-          :service => "platform.topological-inventory.task-output-stream",
-          :event   => "Task.update",
-          :payload => params_for_update.to_h.merge("task_id" => params.require(:id))
-        )
+        if ENV['NO_KAFKA'].blank?
+          messaging_client.publish_topic(
+            :service => "platform.topological-inventory.task-output-stream",
+            :event   => "Task.update",
+            :payload => params_for_update.to_h.merge("task_id" => params.require(:id)),
+            :headers => Insights::API::Common::Request.current_forwardable
+          )
+        end
 
         head :no_content
       end

--- a/spec/controllers/api/v1x0/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1x0/tasks_controller_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Api::V1x0::TasksController, :type => :request do
     expect(client).to receive(:publish_topic).with(
       :service => "platform.topological-inventory.task-output-stream",
       :event   => "Task.update",
-      :payload => {"state" => "completed", "status" => "ok", "context" => { :message => "context2" }, "task_id" => task.id.to_s}
+      :payload => {"state" => "completed", "status" => "ok", "context" => { :message => "context2" }, "task_id" => task.id.to_s},
+      :headers => {"x-rh-identity" => identity}
     )
 
     patch(api_v1x0_task_url(task.id), :params => {:state => "completed", :status => "ok", :context => { :message => "context2" }}.to_json, :headers => headers)


### PR DESCRIPTION
This PR adds` x-rh-identity` to `Task.update` event in `platform.topological-inventory.task-output-stream` Kafka's topic

---

Headers are originally put first into Topological API: 
* https://github.com/RedHatInsights/topological_inventory-api/blob/master/app/controllers/api/v1/service_offerings_controller.rb#L60
* https://github.com/RedHatInsights/topological_inventory-api/blob/master/app/controllers/api/v1/service_offerings_controller.rb#L73
etc.

Then sent through Kafka to Operations workers, i.e.:
* https://github.com/RedHatInsights/topological_inventory-ansible_tower/blob/dbdba9c699529cfb89baad927853b8a5731701d6/lib/topological_inventory/ansible_tower/operations/processor.rb#L21

And finally sent by update_task to this code, i.e.
* https://github.com/RedHatInsights/topological_inventory-ansible_tower/blob/dbdba9c699529cfb89baad927853b8a5731701d6/lib/topological_inventory/ansible_tower/operations/core/topology_api_client.rb#L15