### PR TITLE
removed guest_applications and added disk size attributes

### DIFF
--- a/config/cfme/manifest_5_11.json
+++ b/config/cfme/manifest_5_11.json
@@ -103,8 +103,12 @@
         "description": null,
         "type": null,
         "uid_ems": null,
+        "last_scan_on": null,
         "cpu_cores_per_socket": null,
         "cpu_total_cores": null,
+        "allocated_disk_storage": null,
+        "used_disk_storage": null,
+        "thin_provisioned": null,
         "disks_aligned": null,
         "ems_ref": null,
         "has_rdm_disk": null,
@@ -119,13 +123,6 @@
           "product_type": null,
           "product_name": null,
           "distribution": null
-        },
-        "guest_applications": {
-          "name": null,
-          "version": null,
-          "typename": null,
-          "arch": null,
-          "release": null
         },
         "hardware": {
           "id": null,
@@ -235,8 +232,12 @@
         "description": null,
         "type": null,
         "uid_ems": null,
+        "last_scan_on": null,
         "cpu_cores_per_socket": null,
         "cpu_total_cores": null,
+        "allocated_disk_storage": null,
+        "used_disk_storage": null,
+        "thin_provisioned": null,
         "disks_aligned": null,
         "ems_ref": null,
         "has_rdm_disk": null,
@@ -251,13 +252,6 @@
           "product_type": null,
           "product_name": null,
           "distribution": null
-        },
-        "guest_applications": {
-          "name": null,
-          "version": null,
-          "typename": null,
-          "arch": null,
-          "release": null
         },
         "hardware": {
           "id": null,

--- a/config/cfme/manifest_5_11.json
+++ b/config/cfme/manifest_5_11.json
@@ -211,7 +211,6 @@
         "uncommitted": null,
         "storage_domain_type": null,
         "host_storages": {
-          "ems_ref": null,
           "host": {
             "ems_ref": null
           }
@@ -357,7 +356,6 @@
         "uncommitted": null,
         "storage_domain_type": null,
         "host_storages": {
-          "ems_ref": null,
           "host": {
             "ems_ref": null
           }


### PR DESCRIPTION
This PR removes the guest_applications section because it makes the payload size too large. It also adds disk storage size attributes so that allocated and used disk sized can be displayed in a Migration Analytics report.

The last_scan_on attribute is needed to determine whether a SmartState Analysis has been performed. If it hasn't then allocated_disk_storage will be the same as used_disk_storage, regardless of whether the disks are or aren't thin provisioned.