### PR TITLE
Remove deprecation warning about request.user.tenant 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,7 +20,7 @@ class ApplicationController < ActionController::API
         if Tenant.tenancy_enabled? && current.required_auth?
           raise Insights::API::Common::EntitlementError unless request_is_entitled?(current.entitlement)
 
-          tenant = Tenant.find_or_create_by(:external_tenant => current.user.tenant) if current.user.tenant
+          tenant = Tenant.find_or_create_by(:external_tenant => current.tenant) if current.tenant
           ActsAsTenant.with_tenant(tenant) { yield }
         else
           ActsAsTenant.without_tenant { yield }


### PR DESCRIPTION
```ruby
DEPRECATION WARNING: Please switch to request.tenant, request.user.tenant will be removed in a future release. (called from block in with_current_request at /home/travis/build/RedHatInsights/topological_inventory-api/app/controllers/application_controller.rb:23)
```


https://travis-ci.org/RedHatInsights/topological_inventory-api/builds/655755071?utm_source=github_status&utm_medium=notification


