### PR TITLE
Add logging for ServiceOffering operations

### DIFF
--- a/app/controllers/api/v1/service_offerings_controller.rb
+++ b/app/controllers/api/v1/service_offerings_controller.rb
@@ -18,12 +18,20 @@ module Api
 
       def send_message_and_generate_task_for(operation_type)
         operation_params = send("params_for_#{operation_type}".to_sym)
+
+        logger.info("Entering method send_message_and_generate_task_for operation #{operation_type} with params #{operation_params.inspect}")
+
         service_offering = model.find(operation_params[:service_offering_id].to_i)
 
         source_type = retrieve_source_type(service_offering)
+        logger.info("Retrieved SourceType(id: #{source_type.id}, name: #{source_type.name}), ServiceOffice(id: #{service_offering.source.id})")
+
         task = Task.create!(:tenant => service_offering.tenant, :state => "pending", :status => "ok")
+        logger.info("Task(id: #{task.id}) created.")
 
         payload = send("payload_for_#{operation_type}".to_sym, task, service_offering)
+
+        logger.info("Task(id: #{task.id}): Publishing event(ServiceOffering.#{operation_type}) to kafka")
 
         messaging_client.publish_topic(
           :service => "platform.topological-inventory.operations-#{source_type.name}",
@@ -31,10 +39,14 @@ module Api
           :payload => payload
         )
 
+        logger.info("Task(id: #{task.id}): event(ServiceOffering.#{operation_type}) published to kafka.")
+
         render :json => {:task_id => task.id}
-      rescue ActiveRecord::RecordNotFound
+      rescue ActiveRecord::RecordNotFound => err
+        logger.error("#{err.message}")
         head :bad_request
       rescue StandardError => err
+        logger.error("#{task ? "Task(id: #{task.id}):" : ""} #{err.message} (#{err.class})")
         error_document = Insights::API::Common::ErrorDocument.new.add(err.message)
         render :json => error_document.to_h, :status => error_document.status
       end


### PR DESCRIPTION
TPINVTRY-838

we are logging hash with some parameters which looks like this, **there is also request-id**:
```
{"@timestamp":"2020-02-28T13:47:08.931310 ","pid":68436,"tid":"3fcda70797c0","level":"info","message":"Task(id: 67): Publishing event(ServiceOffering.order) to kafka","request_id":"TEST"}
```

```
 POST "/api/topological-inventory/v2.0/service_offerings/3/order"
```

Example scenarios (just messages):

**Successful scenario:**
```
Entering method send_message_and_generate_task_for operation order with params {\"service_offering_id\"=\u003e\"3\", \"provider_control_parameters\"=\u003e{}}
Retrieved SourcesApiClient::SourceType(id: 2, name: ansible-tower), Source(id: 2)
Task(id: 65) created.
Task(id: 65): Publishing event(ServiceOffering.order) to kafka
Task(id: 65): event(ServiceOffering.order) published to kafka.
```


**Failing scenario - record not found**

```
Entering method send_message_and_generate_task_for operation order with params {\"service_offering_id\"=\u003e\"30000\", \"provider_control_parameters\"=\u003e{}}
Couldn't find ServiceOffering with 'id'=30000 [WHERE \"service_offerings\".\"tenant_id\" = $1]
```

**Failing scenario - source api is not working**
```
Entering method send_message_and_generate_task_for operation order with params {\"service_offering_id\"=\u003e\"30000\", \"provider_control_parameters\"=\u003e{}}
Sources API: Couldn't connect to server\nHTTP status code: 0 (code 0) (SourcesApiClient::ApiError)
```

**Failing scenario - Kafka is not working**
```
Entering method send_message_and_generate_task_for operation order with params {\"service_offering_id\"=\u003e\"30000\", \"provider_control_parameters\"=\u003e{}}
Retrieved SourceType(id: 2), ServiceOffice(2)
Task(id: 67) created.
Task(id: 67): Publishing event(ServiceOffering.order) to kafka
Could not connect to any of the seed brokers:\n- kafka://localhost:9092: Connection refused - connect(2) for [::1]:9092 (Kafka::ConnectionError)

```



cc @gtanzillo 
