### PR TITLE
Allow subcollection requests to traverse has_many through relations

### DIFF
--- a/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/app/controllers/api/v1/mixins/index_mixin.rb
@@ -24,8 +24,7 @@ module Api
         def raise_unless_primary_instance_exists
           return unless subcollection?
 
-          klass = request_path_parts["primary_collection_name"].singularize.camelize.safe_constantize
-          klass.find(request_path_parts["primary_collection_id"].to_i)
+          primary_instance
         end
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,7 +117,16 @@ class ApplicationController < ActionController::API
   end
 
   def filtered
-    Insights::API::Common::Filter.new(model, safe_params_for_list[:filter], api_doc_definition).apply
+    Insights::API::Common::Filter.new(base_query, safe_params_for_list[:filter], api_doc_definition).apply
+  end
+
+  def base_query
+    subcollection? ? primary_instance.send(request_path_parts["subcollection_name"]) : model
+  end
+
+  def primary_instance
+    klass = request_path_parts["primary_collection_name"].singularize.camelize.safe_constantize
+    klass.find(request_path_parts["primary_collection_id"].to_i)
   end
 
   def pagination_limit


### PR DESCRIPTION
Load the primary instance and walk the declared has_many relation to get the results rather than starting at the class of the subcollection.