### PR TITLE
Bump ruby for travis to 2.5.7 + 2.6.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- 2.4.5
+- 2.5.7
+- 2.6.5
 addons:
   postgresql: '10'
 env:


### PR DESCRIPTION
update ruby for travis to 2.5.7 and 2.6.5. Because core depends on rails, which depends on sprockets without upper limit.
And sprockets 4.0.0 depends on ruby >= 2.5