### PR TITLE
Bump core to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,7 @@ gem 'rack-cors',                       '>= 1.0.4', '~> 1.0'
 gem 'rails',                           '>= 5.2.2.1', '~> 5.2.2'
 gem 'sources-api-client',              '~> 1.0'
 
-gem 'inventory_refresh',          :git => 'https://github.com/ManageIQ/inventory_refresh',                :branch => 'master'
-gem 'topological_inventory-core', :git => 'https://github.com/RedHatInsights/topological_inventory-core', :branch => 'master'
+gem 'topological_inventory-core',      '~> 1.0.0'
 
 group :development, :test do
   gem 'simplecov'


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-core/issues/190

Merged PRs can't affect production with incompatible code

---

- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-core/pull/189 **[ requires RubyGems release ]**