### PR TITLE
Extending Task by x_rh_insights_request column

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'puma',                            '>= 4.3.3', '~> 4.3'
 gem 'rack-cors',                       '>= 1.0.4', '~> 1.0'
 gem 'rails',                           '>= 5.2.2.1', '~> 5.2.2'
 gem 'sources-api-client',              '~> 1.0'
-gem 'topological_inventory-core',      '~> 1.1.1'
+gem 'topological_inventory-core',      '~> 1.1.2'
 
 group :development, :test do
   gem 'simplecov'

--- a/app/controllers/api/v1/service_offerings_controller.rb
+++ b/app/controllers/api/v1/service_offerings_controller.rb
@@ -25,8 +25,7 @@ module Api
 
         source_type = retrieve_source_type(service_offering)
         logger.info("ServiceOffering##{operation_type}: Retrieved SourceType(id: #{source_type.id}, name: #{source_type.name}), ServiceOffering(id: #{service_offering.id}, source_ref: #{service_offering.source_ref})")
-
-        task = Task.create!(:name => "ServiceOffering##{operation_type}", :tenant => service_offering.tenant, :state => "pending", :status => "ok")
+        task = Task.create!(:name => "ServiceOffering##{operation_type}", :x_rh_insights_request => Insights::API::Common::Request.current_forwardable["x-rh-insights-request-id"], :tenant => service_offering.tenant, :state => "pending", :status => "ok")
         logger.info("ServiceOffering##{operation_type}: ServiceOffering(id: #{service_offering.id}, source_ref: #{service_offering.source_ref}): Task(id: #{task.id}) created.")
 
         payload = send("payload_for_#{operation_type}".to_sym, task, service_offering)

--- a/app/controllers/api/v1/service_plans_controller.rb
+++ b/app/controllers/api/v1/service_plans_controller.rb
@@ -10,7 +10,7 @@ module Api
       def order
         service_plan = model.find(request_path_parts["primary_collection_id"].to_i)
         source_type  = retrieve_source_type(service_plan)
-        task         = Task.create!(:name => "ServicePlan#order", :tenant => service_plan.tenant, :state => "pending", :status => "ok")
+        task         = Task.create!(:name => "ServicePlan#order", :x_rh_insights_request => Insights::API::Common::Request.current_forwardable["x-rh-insights-request-id"], :tenant => service_plan.tenant, :state => "pending", :status => "ok")
 
         messaging_client.publish_topic(
           :service => "platform.topological-inventory.operations-#{source_type.name}",

--- a/public/doc/openapi-3-v3.0.json
+++ b/public/doc/openapi-3-v3.0.json
@@ -11338,6 +11338,9 @@
             "format": "date-time",
             "readOnly": true,
             "type": "string"
+          },
+          "x_rh_insights_request": {
+            "type": "string"
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
**Issue** RedHatInsights/topological_inventory-ansible_tower#83

Saving x-rh-insights-request-id header to Task in `ServiceOffering#order`, to be able to send this header to Kafka from Persister.

---

* [ ] **depends on** RedHatInsights/topological_inventory-core#193