### PR TITLE
Update run_rails_server to fail to start container if migrations fail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'puma',                            '>= 4.3.3', '~> 4.3'
 gem 'rack-cors',                       '>= 1.0.4', '~> 1.0'
 gem 'rails',                           '>= 5.2.2.1', '~> 5.2.2'
 gem 'sources-api-client',              '~> 1.0'
-gem 'topological_inventory-core',      '~> 1.1.2'
+gem 'topological_inventory-core',      '~> 1.1.3'
 
 group :development, :test do
   gem 'simplecov'

--- a/docker-assets/run_rails_server
+++ b/docker-assets/run_rails_server
@@ -28,6 +28,4 @@ write_encryption_key
 # Wait for postgres to be ready
 check_svc_status $DATABASE_HOST $DATABASE_PORT
 
-bundle exec rake db:migrate
-bundle exec rake db:seed
-bundle exec rails server
+bundle exec rake db:migrate && bundle exec rake db:seed && bundle exec rails server


### PR DESCRIPTION
We found a migration that had failed to run which is causing ordering to be broken since columns that are needed aren't part of the tables.

This PR includes a fix to said migration as well as updating the run script to fail starting the container if migrations fail, this way the migration will be evident immediately. 

-----

The migration fix is here: https://github.com/RedHatInsights/topological_inventory-core/pull/194

This change will cause the pod to _NOT_ start successfully if the mgiration fails, so topo-api would effectively be down until that migration gets merged + released. So we should probably wait until that is done. 