### PR TITLE
Rename task_id key to id

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -11,7 +11,7 @@ module Api
           messaging_client.publish_topic(
             :service => "platform.topological-inventory.task-output-stream",
             :event   => "Task.update",
-            :payload => params_for_update.to_h.merge("task_id" => params.require(:id)),
+            :payload => params_for_update.to_h.merge("id" => params.require(:id)),
             :headers => Insights::API::Common::Request.current_forwardable
           )
         end

--- a/spec/controllers/api/v1x0/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1x0/tasks_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::V1x0::TasksController, :type => :request do
     expect(client).to receive(:publish_topic).with(
       :service => "platform.topological-inventory.task-output-stream",
       :event   => "Task.update",
-      :payload => {"state" => "completed", "status" => "ok", "context" => { :message => "context2" }, "task_id" => task.id.to_s},
+      :payload => {"state" => "completed", "status" => "ok", "context" => { :message => "context2" }, "id" => task.id.to_s},
       :headers => {"x-rh-identity" => identity}
     )
 


### PR DESCRIPTION
Renames the task_id key to id for all task update events.

This brings the operations events inline with persister events that were already including an 'id' key.

This PR is required for https://github.com/RedHatInsights/catalog-api-minion/pull/34 to work correctly.