### PR TITLE
Changed status to string, make specs compatible with latest common gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem 'activerecord-virtual_attributes', '~> 1.5'
-gem 'insights-api-common',             '=  3.8'
+gem 'insights-api-common',             '~> 4.0'
 gem 'jbuilder',                        '~> 2.0'
 gem 'json-schema',                     '~> 2.8'
 gem 'manageiq-loggers',                "~> 0.4.0", ">= 0.4.2"

--- a/app/controllers/api.rb
+++ b/app/controllers/api.rb
@@ -3,7 +3,7 @@ module Api
     skip_before_action :validate_primary_collection_id
 
     def invalid_url_error
-      error_document = Insights::API::Common::ErrorDocument.new.add(404, "Invalid URL /#{params[:path]} specified.")
+      error_document = Insights::API::Common::ErrorDocument.new.add("404", "Invalid URL /#{params[:path]} specified.")
       render :json => error_document.to_h, :status => :not_found
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
   around_action :with_current_request
 
   rescue_from ActiveRecord::RecordNotFound do |exception|
-    error_document = Insights::API::Common::ErrorDocument.new.add(404, "Record not found")
+    error_document = Insights::API::Common::ErrorDocument.new.add("404", "Record not found")
     render :json => error_document.to_h, :status => :not_found
   end
 
@@ -26,10 +26,10 @@ class ApplicationController < ActionController::API
           ActsAsTenant.without_tenant { yield }
         end
       rescue KeyError, Insights::API::Common::IdentityError
-        error_document = Insights::API::Common::ErrorDocument.new.add(401, 'Unauthorized')
+        error_document = Insights::API::Common::ErrorDocument.new.add('401', 'Unauthorized')
         render :json => error_document.to_h, :status => error_document.status
       rescue Insights::API::Common::EntitlementError
-        error_document = Insights::API::Common::ErrorDocument.new.add(403, 'Forbidden')
+        error_document = Insights::API::Common::ErrorDocument.new.add('403', 'Forbidden')
         render :json => error_document.to_h, :status => error_document.status
       end
     end

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe("::Insights::API::Common::Filter") do
 
     expect(response).to have_attributes(
       :parsed_body => {
-        "errors" => errors.collect { |e| {"detail" => e, "status" => 400} }
+        "errors" => errors.collect { |e| {"detail" => e, "status" => "400"} }
       },
       :status      => 400,
     )
@@ -131,9 +131,9 @@ RSpec.describe("::Insights::API::Common::Filter") do
     it("unknown attribute") { expect_failure("filter[xxx]", "Insights::API::Common::Filter::Error: found unpermitted parameter: xxx") }
 
     context "unsupported comparator" do
-      it("on an integer")  { expect_failure("filter[id][xxx]=4", "Insights::API::Common::Filter::Error: unsupported integer comparator: xxx") }
-      it("on a string")    { expect_failure("filter[name][xxx]=4", "Insights::API::Common::Filter::Error: unsupported string comparator: xxx") }
-      it("on a timestamp") { expect_failure("filter[created_at][xxx]=4", "Insights::API::Common::Filter::Error: unsupported timestamp comparator: xxx") }
+      it("on an integer")  { expect_failure("filter[id][xxx]=4", "Insights::API::Common::Filter::Error: found unpermitted parameter: id.xxx") }
+      it("on a string")    { expect_failure("filter[name][xxx]=4", "Insights::API::Common::Filter::Error: found unpermitted parameter: name.xxx") }
+      it("on a timestamp") { expect_failure("filter[created_at][xxx]=4", "Insights::API::Common::Filter::Error: found unpermitted parameter: created_at.xxx") }
     end
 
     it "unsupported attribute type" do
@@ -143,7 +143,7 @@ RSpec.describe("::Insights::API::Common::Filter") do
       get("/api/v1.0/vms?filter[mac_addresses]=a", :headers => headers)
 
       expect(response.status).to eq(400)
-      expect(response.parsed_body["errors"]).to eq([{"detail"=>"Insights::API::Common::Filter::Error: unsupported attribute type for: mac_addresses", "status"=>400}])
+      expect(response.parsed_body["errors"]).to eq([{"detail"=>"Insights::API::Common::Filter::Error: unsupported attribute type for: mac_addresses", "status"=>"400"}])
     end
 
     it "invalid attribute" do
@@ -153,7 +153,7 @@ RSpec.describe("::Insights::API::Common::Filter") do
       get("/api/v1.0/vms?filter[bogus_attribute]=a", :headers => headers)
 
       expect(response.status).to eq(400)
-      expect(response.parsed_body["errors"]).to eq([{"detail"=>"Insights::API::Common::Filter::Error: found unpermitted parameter: bogus_attribute", "status"=>400}])
+      expect(response.parsed_body["errors"]).to eq([{"detail"=>"Insights::API::Common::Filter::Error: found unpermitted parameter: bogus_attribute", "status"=>"400"}])
     end
 
     it "multiple invalid attributes mixed with a valid attribute" do
@@ -165,7 +165,7 @@ RSpec.describe("::Insights::API::Common::Filter") do
       expect(response.status).to eq(400)
       expect(response.parsed_body["errors"]).to eq(
         [
-          {"detail" => "Insights::API::Common::Filter::Error: unsupported attribute type for: mac_addresses, found unpermitted parameter: bogus_attribute", "status" => 400}
+          {"detail" => "Insights::API::Common::Filter::Error: unsupported attribute type for: mac_addresses, found unpermitted parameter: bogus_attribute", "status" => "400"}
         ]
       )
     end

--- a/spec/requests/api/v1.0/service_offering_icon_spec.rb
+++ b/spec/requests/api/v1.0/service_offering_icon_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe("v1.0 - ServiceOfferingIcon") do
 
         expect(response).to have_attributes(
                               :status      => 404,
-                              :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]},
+                              :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]},
                             )
       end
 
@@ -66,7 +66,7 @@ RSpec.describe("v1.0 - ServiceOfferingIcon") do
 
         expect(response).to have_attributes(
                               :status      => 400,
-                              :parsed_body => {"errors"=>[{"detail"=>"Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status"=>400}]},
+                              :parsed_body => {"errors"=>[{"detail"=>"Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status"=>"400"}]},
                             )
       end
     end

--- a/spec/requests/api/v1.0/shared_examples_for_index.rb
+++ b/spec/requests/api/v1.0/shared_examples_for_index.rb
@@ -50,7 +50,7 @@ RSpec.shared_examples "v1x0_test_index_and_subcollections" do |primary_collectio
 
         expect(response).to have_attributes(
                               :status      => 404,
-                              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+                              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
                             )
       end
 
@@ -59,7 +59,7 @@ RSpec.shared_examples "v1x0_test_index_and_subcollections" do |primary_collectio
 
         expect(response).to have_attributes(
                               :status      => 400,
-                              :parsed_body => {"errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => 400}]}
+                              :parsed_body => {"errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => "400"}]}
                             )
       end
     end
@@ -95,7 +95,7 @@ RSpec.shared_examples "v1x0_test_index_and_subcollections" do |primary_collectio
 
             expect(response).to have_attributes(
                                   :status      => 404,
-                                  :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+                                  :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
                                 )
           end
 
@@ -104,7 +104,7 @@ RSpec.shared_examples "v1x0_test_index_and_subcollections" do |primary_collectio
 
             expect(response).to have_attributes(
                                   :status      => 400,
-                                  :parsed_body => {"errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => 400}]}
+                                  :parsed_body => {"errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => "400"}]}
                                 )
           end
         end

--- a/spec/requests/api/v2.0/filter_spec.rb
+++ b/spec/requests/api/v2.0/filter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe("::Insights::API::Common::Filter") do
 
     expect(response).to have_attributes(
       :parsed_body => {
-        "errors" => errors.collect { |e| {"detail" => e, "status" => 400} }
+        "errors" => errors.collect { |e| {"detail" => e, "status" => "400"} }
       },
       :status      => 400,
     )
@@ -131,9 +131,9 @@ RSpec.describe("::Insights::API::Common::Filter") do
     it("unknown attribute") { expect_failure("filter[xxx]", "Insights::API::Common::Filter::Error: found unpermitted parameter: xxx") }
 
     context "unsupported comparator" do
-      it("on an integer")  { expect_failure("filter[id][xxx]=4", "Insights::API::Common::Filter::Error: unsupported integer comparator: xxx") }
-      it("on a string")    { expect_failure("filter[name][xxx]=4", "Insights::API::Common::Filter::Error: unsupported string comparator: xxx") }
-      it("on a timestamp") { expect_failure("filter[created_at][xxx]=4", "Insights::API::Common::Filter::Error: unsupported timestamp comparator: xxx") }
+      it("on an integer")  { expect_failure("filter[id][xxx]=4", "Insights::API::Common::Filter::Error: found unpermitted parameter: id.xxx") }
+      it("on a string")    { expect_failure("filter[name][xxx]=4", "Insights::API::Common::Filter::Error: found unpermitted parameter: name.xxx") }
+      it("on a timestamp") { expect_failure("filter[created_at][xxx]=4", "Insights::API::Common::Filter::Error: found unpermitted parameter: created_at.xxx") }
     end
 
     it "unsupported attribute type" do
@@ -143,7 +143,7 @@ RSpec.describe("::Insights::API::Common::Filter") do
       get("/api/v2.0/vms?filter[mac_addresses]=a", :headers => headers)
 
       expect(response.status).to eq(400)
-      expect(response.parsed_body["errors"]).to eq([{"detail"=>"Insights::API::Common::Filter::Error: unsupported attribute type for: mac_addresses", "status"=>400}])
+      expect(response.parsed_body["errors"]).to eq([{"detail"=>"Insights::API::Common::Filter::Error: unsupported attribute type for: mac_addresses", "status"=>"400"}])
     end
 
     it "invalid attribute" do
@@ -153,7 +153,7 @@ RSpec.describe("::Insights::API::Common::Filter") do
       get("/api/v2.0/vms?filter[bogus_attribute]=a", :headers => headers)
 
       expect(response.status).to eq(400)
-      expect(response.parsed_body["errors"]).to eq([{"detail"=>"Insights::API::Common::Filter::Error: found unpermitted parameter: bogus_attribute", "status"=>400}])
+      expect(response.parsed_body["errors"]).to eq([{"detail"=>"Insights::API::Common::Filter::Error: found unpermitted parameter: bogus_attribute", "status"=>"400"}])
     end
 
     it "multiple invalid attributes mixed with a valid attribute" do
@@ -165,7 +165,7 @@ RSpec.describe("::Insights::API::Common::Filter") do
       expect(response.status).to eq(400)
       expect(response.parsed_body["errors"]).to eq(
         [
-          {"detail" => "Insights::API::Common::Filter::Error: unsupported attribute type for: mac_addresses, found unpermitted parameter: bogus_attribute", "status" => 400}
+          {"detail" => "Insights::API::Common::Filter::Error: unsupported attribute type for: mac_addresses, found unpermitted parameter: bogus_attribute", "status" => "400"}
         ]
       )
     end

--- a/spec/requests/api/v2.0/service_offering_icon_spec.rb
+++ b/spec/requests/api/v2.0/service_offering_icon_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe("v2.0 - ServiceOfferingIcon") do
 
         expect(response).to have_attributes(
                               :status      => 404,
-                              :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]},
+                              :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]},
                             )
       end
 
@@ -66,7 +66,7 @@ RSpec.describe("v2.0 - ServiceOfferingIcon") do
 
         expect(response).to have_attributes(
                               :status      => 400,
-                              :parsed_body => {"errors"=>[{"detail"=>"Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status"=>400}]},
+                              :parsed_body => {"errors"=>[{"detail"=>"Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status"=>"400"}]},
                             )
       end
     end

--- a/spec/requests/api/v2.0/shared_examples_for_index.rb
+++ b/spec/requests/api/v2.0/shared_examples_for_index.rb
@@ -53,7 +53,7 @@ RSpec.shared_examples "v2x0_test_index_and_subcollections" do |primary_collectio
 
         expect(response).to have_attributes(
                               :status      => 404,
-                              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+                              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
                             )
       end
 
@@ -62,7 +62,7 @@ RSpec.shared_examples "v2x0_test_index_and_subcollections" do |primary_collectio
 
         expect(response).to have_attributes(
                               :status      => 400,
-                              :parsed_body => {"errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => 400}]}
+                              :parsed_body => {"errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => "400"}]}
                             )
       end
     end
@@ -98,7 +98,7 @@ RSpec.shared_examples "v2x0_test_index_and_subcollections" do |primary_collectio
 
             expect(response).to have_attributes(
                                   :status      => 404,
-                                  :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+                                  :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
                                 )
           end
 
@@ -107,7 +107,7 @@ RSpec.shared_examples "v2x0_test_index_and_subcollections" do |primary_collectio
 
             expect(response).to have_attributes(
                                   :status      => 400,
-                                  :parsed_body => {"errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => 400}]}
+                                  :parsed_body => {"errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => "400"}]}
                                 )
           end
         end

--- a/spec/requests/api/v3.0/filter_spec.rb
+++ b/spec/requests/api/v3.0/filter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe("::Insights::API::Common::Filter") do
 
     expect(response).to have_attributes(
       :parsed_body => {
-        "errors" => errors.collect { |e| {"detail" => e, "status" => 400} }
+        "errors" => errors.collect { |e| {"detail" => e, "status" => "400"} }
       },
       :status      => 400,
     )
@@ -140,9 +140,9 @@ RSpec.describe("::Insights::API::Common::Filter") do
     it("unknown attribute") { expect_failure("filter[xxx]", "Insights::API::Common::Filter::Error: found unpermitted parameter: xxx") }
 
     context "unsupported comparator" do
-      it("on an integer")  { expect_failure("filter[id][xxx]=4", "Insights::API::Common::Filter::Error: unsupported integer comparator: xxx") }
-      it("on a string")    { expect_failure("filter[name][xxx]=4", "Insights::API::Common::Filter::Error: unsupported string comparator: xxx") }
-      it("on a timestamp") { expect_failure("filter[created_at][xxx]=4", "Insights::API::Common::Filter::Error: unsupported timestamp comparator: xxx") }
+      it("on an integer")  { expect_failure("filter[id][xxx]=4", "Insights::API::Common::Filter::Error: found unpermitted parameter: id.xxx") }
+      it("on a string")    { expect_failure("filter[name][xxx]=4", "Insights::API::Common::Filter::Error: found unpermitted parameter: name.xxx") }
+      it("on a timestamp") { expect_failure("filter[created_at][xxx]=4", "Insights::API::Common::Filter::Error: found unpermitted parameter: created_at.xxx") }
     end
 
     it "unsupported attribute type" do
@@ -152,7 +152,7 @@ RSpec.describe("::Insights::API::Common::Filter") do
       get("/api/v3.0/vms?filter[mac_addresses]=a", :headers => headers)
 
       expect(response.status).to eq(400)
-      expect(response.parsed_body["errors"]).to eq([{"detail"=>"Insights::API::Common::Filter::Error: unsupported attribute type for: mac_addresses", "status"=>400}])
+      expect(response.parsed_body["errors"]).to eq([{"detail"=>"Insights::API::Common::Filter::Error: unsupported attribute type for: mac_addresses", "status"=>"400"}])
     end
 
     it "invalid attribute" do
@@ -162,7 +162,7 @@ RSpec.describe("::Insights::API::Common::Filter") do
       get("/api/v3.0/vms?filter[bogus_attribute]=a", :headers => headers)
 
       expect(response.status).to eq(400)
-      expect(response.parsed_body["errors"]).to eq([{"detail"=>"Insights::API::Common::Filter::Error: found unpermitted parameter: bogus_attribute", "status"=>400}])
+      expect(response.parsed_body["errors"]).to eq([{"detail"=>"Insights::API::Common::Filter::Error: found unpermitted parameter: bogus_attribute", "status"=>"400"}])
     end
 
     it "multiple invalid attributes mixed with a valid attribute" do
@@ -174,7 +174,7 @@ RSpec.describe("::Insights::API::Common::Filter") do
       expect(response.status).to eq(400)
       expect(response.parsed_body["errors"]).to eq(
         [
-          {"detail" => "Insights::API::Common::Filter::Error: unsupported attribute type for: mac_addresses, found unpermitted parameter: bogus_attribute", "status" => 400}
+          {"detail" => "Insights::API::Common::Filter::Error: unsupported attribute type for: mac_addresses, found unpermitted parameter: bogus_attribute", "status" => "400"}
         ]
       )
     end

--- a/spec/requests/api/v3.0/service_offering_icon_spec.rb
+++ b/spec/requests/api/v3.0/service_offering_icon_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe("v3.0 - ServiceOfferingIcon") do
 
         expect(response).to have_attributes(
                               :status      => 404,
-                              :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]},
+                              :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]},
                             )
       end
 
@@ -66,7 +66,7 @@ RSpec.describe("v3.0 - ServiceOfferingIcon") do
 
         expect(response).to have_attributes(
                               :status      => 400,
-                              :parsed_body => {"errors"=>[{"detail"=>"Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status"=>400}]},
+                              :parsed_body => {"errors"=>[{"detail"=>"Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status"=>"400"}]},
                             )
       end
     end

--- a/spec/requests/api/v3.0/shared_examples_for_index.rb
+++ b/spec/requests/api/v3.0/shared_examples_for_index.rb
@@ -53,7 +53,7 @@ RSpec.shared_examples "v3x0_test_index_and_subcollections" do |primary_collectio
 
         expect(response).to have_attributes(
                               :status      => 404,
-                              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+                              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
                             )
       end
 
@@ -62,7 +62,7 @@ RSpec.shared_examples "v3x0_test_index_and_subcollections" do |primary_collectio
 
         expect(response).to have_attributes(
                               :status      => 400,
-                              :parsed_body => {"errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => 400}]}
+                              :parsed_body => {"errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => "400"}]}
                             )
       end
     end
@@ -98,7 +98,7 @@ RSpec.shared_examples "v3x0_test_index_and_subcollections" do |primary_collectio
 
             expect(response).to have_attributes(
                                   :status      => 404,
-                                  :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+                                  :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
                                 )
           end
 
@@ -107,7 +107,7 @@ RSpec.shared_examples "v3x0_test_index_and_subcollections" do |primary_collectio
 
             expect(response).to have_attributes(
                                   :status      => 400,
-                                  :parsed_body => {"errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => 400}]}
+                                  :parsed_body => {"errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => "400"}]}
                                 )
           end
         end

--- a/spec/requests/general_spec.rb
+++ b/spec/requests/general_spec.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples "invalid_url_requests" do |request_type, invalid_url|
 
       expect(response).to have_attributes(
         :status      => 404,
-        :parsed_body => {"errors" => [{"detail" => "Invalid URL #{invalid_url} specified.", "status" => 404}]}
+        :parsed_body => {"errors" => [{"detail" => "Invalid URL #{invalid_url} specified.", "status" => "404"}]}
       )
     end
   end


### PR DESCRIPTION
The filter error messages have been fixed
Status for error objects have been converted to string

https://projects.engineering.redhat.com/browse/TPINVTRY-925