### PR TITLE
Excluding forwardable_headers from OpenAPI definitions.

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -126,6 +126,10 @@ class OpenapiGenerator < Insights::API::Common::OpenApi::Generator
       'VolumeType',
     ].to_set.freeze
   end
+
+  def generator_blacklist_allowed_attributes
+    super.merge(:forwardable_headers => true)
+  end
 end
 
 namespace :openapi do


### PR DESCRIPTION
Excluding forwardable_headers from OpenAPI definitions.

Based on https://projects.engineering.redhat.com/browse/TPINVTRY-932.