### PR TITLE
Added source_id to new Tasks

### DIFF
--- a/app/controllers/api/v1/service_offerings_controller.rb
+++ b/app/controllers/api/v1/service_offerings_controller.rb
@@ -25,7 +25,7 @@ module Api
 
         source_type = retrieve_source_type(service_offering)
         logger.info("ServiceOffering##{operation_type}: Retrieved SourceType(id: #{source_type.id}, name: #{source_type.name}), ServiceOffering(id: #{service_offering.id}, source_ref: #{service_offering.source_ref})")
-        task = Task.create!(:name => "ServiceOffering##{operation_type}", :forwardable_headers => Insights::API::Common::Request.current_forwardable, :tenant => service_offering.tenant, :state => "pending", :status => "ok")
+        task = Task.create!(:name => "ServiceOffering##{operation_type}", :source_id => service_offering.source_id, :forwardable_headers => Insights::API::Common::Request.current_forwardable, :tenant => service_offering.tenant, :state => "pending", :status => "ok")
         logger.info("ServiceOffering##{operation_type}: ServiceOffering(id: #{service_offering.id}, source_ref: #{service_offering.source_ref}): Task(id: #{task.id}) created.")
 
         payload = send("payload_for_#{operation_type}".to_sym, task, service_offering)

--- a/app/controllers/api/v1/service_plans_controller.rb
+++ b/app/controllers/api/v1/service_plans_controller.rb
@@ -10,7 +10,7 @@ module Api
       def order
         service_plan = model.find(request_path_parts["primary_collection_id"].to_i)
         source_type  = retrieve_source_type(service_plan)
-        task         = Task.create!(:name => "ServicePlan#order", :forwardable_headers => Insights::API::Common::Request.current_forwardable, :tenant => service_plan.tenant, :state => "pending", :status => "ok")
+        task         = Task.create!(:name => "ServicePlan#order", :source_id => service_plan.source_id, :forwardable_headers => Insights::API::Common::Request.current_forwardable, :tenant => service_plan.tenant, :state => "pending", :status => "ok")
 
         messaging_client.publish_topic(
           :service => "platform.topological-inventory.operations-#{source_type.name}",


### PR DESCRIPTION
Adding the `source_id` to `Task.create` for applied_inventories and order operations.
Until now is was added only for order in the operations worker. 