### PR TITLE
Rails metrics from PrometheusExporter::Middleware

### DIFF
--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -1,0 +1,6 @@
+if Rails.env != "test" && ENV['METRICS_PORT'].to_i != 0
+  require 'prometheus_exporter/middleware'
+
+  # This reports stats per request like HTTP status and timings
+  Rails.application.middleware.unshift(PrometheusExporter::Middleware)
+end


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-api/issues/320

Prometheus exporter offers middleware for adding rails-related metrics:

prefix: topological_inventory_api_
- http_requests_total
- http_duration_seconds [_sum|_count]
- http_redis_duration_seconds
- http_sql_duration_seconds
- http_queue_duration_seconds

we can use for alerts and grafana