### PR TITLE
Metrics env check fix + Gitignore to grafana JSON files and link to doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /db/schema.rb
 /doc/
 /Gemfile.lock
+/grafana-dashboards/*.json
 /log/
 /pkg/
 /public/doc/*.jar

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,8 @@ module TopologicalInventory
 
     config.log_level = (ENV['RAILS_LOG_LEVEL'] || 'debug').downcase.to_sym
     Insights::API::Common::Logging.activate(config)
+    # TODO: add an option to disable web_server_metrics
+    # TODO: it's almost the same like PrometheusExporter::Middleware but with less data
     Insights::API::Common::Metrics.activate(config, "topological_inventory_api")
   end
 end

--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -1,4 +1,4 @@
-if Rails.env != "test" && ENV['METRICS_PORT'].to_i != 0
+if Rails.env != "test" && ENV['METRICS_PORT'].to_s != '0'
   require 'prometheus_exporter/middleware'
 
   # This reports stats per request like HTTP status and timings

--- a/grafana-dashboards/README.md
+++ b/grafana-dashboards/README.md
@@ -1,0 +1,3 @@
+# Grafana dashboards documentation
+
+You can find it [there](https://github.com/RedHatInsights/topological_inventory-guides/blob/master/doc/grafana.md)


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-api/issues/320

Just a small addition to #322. 
Gragana dashboard changes have to be exported to JSON as frequently as possible because you never know when it will be replaced by appsre. 

And JSONs are then converted to configmaps, so storing them locally in the same folder makes sense to me.

This PR also adds a link to documentation in Topological Inventory Guides.

EDIT: Changed check for `ENV["METRICS_PORT"]` which is not ignoring default settings

- [ ] https://github.com/RedHatInsights/topological_inventory-guides/pull/36 (depends on, but doesn't need to wait for it)