### PR TITLE
Remove `config.log_level = :debug` from environments/production.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,10 +39,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
-
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-10286


This is why the log level is ALWAYS DEBUG in production mode. 

By removing this line it will respect what we set in `config/application.rb` and thus the ENV var in the template.
