### PR TITLE
Move `messaging_client` to a singleton class to prevent threading issues

### DIFF
--- a/app/controllers/api/v1/service_offerings_controller.rb
+++ b/app/controllers/api/v1/service_offerings_controller.rb
@@ -32,7 +32,7 @@ module Api
 
         logger.info("ServiceOffering##{operation_type}: Task(id: #{task.id}), ServiceOffering(id: #{service_offering.id}, source_ref: #{service_offering.source_ref}): Publishing event(ServiceOffering.#{operation_type}) to kafka")
 
-        messaging_client.publish_topic(
+        TopologicalInventory::Api::Messaging.client.publish_topic(
           :service => "platform.topological-inventory.operations-#{source_type.name}",
           :event   => "ServiceOffering.#{operation_type}",
           :payload => payload

--- a/app/controllers/api/v1/service_plans_controller.rb
+++ b/app/controllers/api/v1/service_plans_controller.rb
@@ -12,7 +12,7 @@ module Api
         source_type  = retrieve_source_type(service_plan)
         task         = Task.create!(:name => "ServicePlan#order", :source_id => service_plan.source_id, :forwardable_headers => Insights::API::Common::Request.current_forwardable, :tenant => service_plan.tenant, :state => "pending", :status => "ok")
 
-        messaging_client.publish_topic(
+        TopologicalInventory::Api::Messaging.client.publish_topic(
           :service => "platform.topological-inventory.operations-#{source_type.name}",
           :event   => "ServicePlan.order",
           :payload => payload_for_order(task, service_plan)

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -8,7 +8,7 @@ module Api
         model.update(params.require(:id), params_for_update)
 
         if ENV['NO_KAFKA'].blank?
-          messaging_client.publish_topic(
+          TopologicalInventory::Api::Messaging.client.publish_topic(
             :service => "platform.topological-inventory.task-output-stream",
             :event   => "Task.update",
             :payload => params_for_update.to_h.merge("id" => params.require(:id)),

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -169,15 +169,4 @@ class ApplicationController < ActionController::API
   def params_for_update
     body_params.permit(*api_doc_definition.all_attributes - api_doc_definition.read_only_attributes)
   end
-
-  def messaging_client
-    require "manageiq-messaging"
-
-    @messaging_client ||= ManageIQ::Messaging::Client.open({
-      :protocol => :Kafka,
-      :host     => ENV["QUEUE_HOST"] || "localhost",
-      :port     => ENV["QUEUE_PORT"] || "9092",
-      :encoding => "json"
-    })
-  end
 end

--- a/lib/topological_inventory/api/messaging.rb
+++ b/lib/topological_inventory/api/messaging.rb
@@ -1,0 +1,16 @@
+module TopologicalInventory
+  module Api
+    module Messaging
+      def self.client
+        require "manageiq-messaging"
+
+        @client ||= ManageIQ::Messaging::Client.open({
+          :protocol => :Kafka,
+          :host     => ENV["QUEUE_HOST"] || "localhost",
+          :port     => ENV["QUEUE_PORT"] || "9092",
+          :encoding => "json"
+        })
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1x0/service_plans_controller_spec.rb
+++ b/spec/controllers/api/v1x0/service_plans_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Api::V1x0::ServicePlansController, :type => :request do
       end
 
       before do
-        allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
+        allow(TopologicalInventory::Api::Messaging).to receive(:client).and_return(client)
         allow(client).to receive(:publish_topic)
 
         source_type = double
@@ -82,7 +82,7 @@ RSpec.describe Api::V1x0::ServicePlansController, :type => :request do
       let(:error_message) { "Sample error message" }
 
       before do
-        allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
+        allow(TopologicalInventory::Api::Messaging).to receive(:client).and_return(client)
         allow(client).to receive(:publish_topic)
 
         allow_any_instance_of(described_class).to receive(:retrieve_source_type).and_raise(SourcesApiClient::ApiError.new(error_message))

--- a/spec/controllers/api/v1x0/tasks_controller_spec.rb
+++ b/spec/controllers/api/v1x0/tasks_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::V1x0::TasksController, :type => :request do
   let(:client)  { instance_double("ManageIQ::Messaging::Client") }
 
   before do
-    allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
+    allow(TopologicalInventory::Api::Messaging).to receive(:client).and_return(client)
     allow(client).to receive(:publish_topic)
   end
 


### PR DESCRIPTION
Looking at production after pushing the `rdkafka` changes we are running out of threads just like in Ingress API, turns out that the messaging_client was an instance method that created a new client every time and never closed it, thus leading to running out of threads eventually.

This fix just moves it to a singleton class.
