### PR TITLE
Update travis URL in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Topological Inventory API
 
-[![Build Status](https://travis-ci.org/RedHatInsights/topological_inventory-api.svg)](https://travis-ci.org/RedHatInsights/topological_inventory-api)
+[![Build Status](https://travis-ci.com/RedHatInsights/topological_inventory-api.svg)](https://travis-ci.com/RedHatInsights/topological_inventory-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/47776e67dbb7cc572c3b/maintainability)](https://codeclimate.com/github/RedHatInsights/topological_inventory-api/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/47776e67dbb7cc572c3b/test_coverage)](https://codeclimate.com/github/RedHatInsights/topological_inventory-api/test_coverage)
 [![Security](https://hakiri.io/github/RedHatInsights/topological_inventory-api/master.svg)](https://hakiri.io/github/RedHatInsights/topological_inventory-api/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on https://github.com/RedHatInsights/topological_inventory-api/issues/334 issue.