### PR TITLE
Configurable DB Pool size

### DIFF
--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -8,6 +8,6 @@ safeuser=$(urlescape ${DATABASE_USER})
 safepass=$(urlescape ${DATABASE_PASSWORD})
 
 export RAILS_ENV=production
-export DATABASE_URL="postgresql://${safeuser}:${safepass}@${DATABASE_HOST}:${DATABASE_PORT}/topological_inventory_production?encoding=utf8&pool=5&wait_timeout=5"
+export DATABASE_URL="postgresql://${safeuser}:${safepass}@${DATABASE_HOST}:${DATABASE_PORT}/topological_inventory_production?encoding=utf8&pool=${DB_POOL_SIZE:-5}&wait_timeout=5"
 
 exec ${@}


### PR DESCRIPTION
Makes db pool size configurable by ENV. Defaults to 5 (current value)

- [x] **depends on** https://github.com/RedHatInsights/e2e-deploy/pull/2831
---

[RHCLOUD-12757](https://issues.redhat.com/browse/RHCLOUD-12757)