### PR TITLE
Disable GraphQL introspection for rails production env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 
 gem 'activerecord-virtual_attributes', '~> 1.5'
 gem 'cloudwatchlogger',                '~> 0.2.1'
-gem 'insights-api-common',             '~> 4.0'
+gem 'insights-api-common',             '~> 5.0', '>= 5.0.2'
 gem 'jbuilder',                        '~> 2.0'
 gem 'json-schema',                     '~> 2.8'
 gem 'manageiq-loggers',                "~> 0.4.0", ">= 0.4.2"

--- a/lib/topological_inventory/api/graphql/templates/schema.erb
+++ b/lib/topological_inventory/api/graphql/templates/schema.erb
@@ -1,0 +1,8 @@
+Schema = ::GraphQL::Schema.define do
+  use ::GraphQL::Batch
+  enable_preloading
+  disable_introspection_entry_points if Rails.env.production?
+
+  query QueryType
+end
+


### PR DESCRIPTION
This configuration disable to perform introspection queries which are described [here]( https://graphql.org/learn/introspection/).
How file(`lib/topological_inventory/api/graphql/templates/schema.erb `) in this PR is loaded is described in this [PR](https://github.com/RedHatInsights/insights-api-common-rails/pull/221).

### Links
Fixes: https://issues.redhat.com/browse/RHCLOUD-11179
**WIP reason**: 
Depends on 
- [x] https://github.com/RedHatInsights/insights-api-common-rails/pull/221
- [x] https://github.com/RedHatInsights/insights-api-common-rails/pull/222
