### PR TITLE
Use insights-loggers-ruby gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,12 @@ RUN chgrp -R 0 $WORKDIR && \
 
 EXPOSE 3000
 
-ENTRYPOINT ["entrypoint"]
+RUN chgrp -R 0 $WORKDIR && \
+    chmod -R g=u $WORKDIR && \
+    curl -L -o /usr/bin/haberdasher \
+    https://github.com/RedHatInsights/haberdasher/releases/latest/download/haberdasher_linux_amd64 && \
+    chmod 755 /usr/bin/haberdasher
+
+ENTRYPOINT ["/usr/bin/haberdasher"]
+
 CMD ["run_rails_server"]

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,9 @@ plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem 'activerecord-virtual_attributes', '~> 1.5'
-gem 'cloudwatchlogger',                '~> 0.2.1'
-gem 'insights-api-common',             '~> 5.0', '>= 5.0.2'
+gem 'insights-api-common', :git => 'https://github.com/lpichler/manageiq-api-common', :branch => 'use_insights_logger_ruby_gem'
 gem 'jbuilder',                        '~> 2.0'
 gem 'json-schema',                     '~> 2.8'
-gem 'manageiq-loggers',                "~> 0.4.0", ">= 0.4.2"
 gem 'manageiq-messaging',              '~> 1.0.0'
 gem 'manageiq-password',               '~> 0.2', ">= 0.2.1"
 gem 'mimemagic',                       '~> 0.3.3'
@@ -17,7 +15,7 @@ gem 'pg',                              '~> 1.0', :require => false
 gem 'puma',                            '~> 4.3.5', '>= 4.3.5'
 gem 'rack-cors',                       '>= 1.0.4'
 gem 'rails',                           '>= 5.2.2.1', '~> 5.2.2'
-gem 'sources-api-client',              '~> 1.0'
+gem 'sources-api-client',              '~> 3.0'
 gem 'topological_inventory-core',      '~> 1.2.1'
 
 group :development, :test do

--- a/app/controllers/api/v3x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v3x0/mixins/index_mixin.rb
@@ -3,6 +3,12 @@ module Api
     module Mixins
       module IndexMixin
         def index
+          if params[:test]
+            Rails.logger.info("STDERR_TP_API test_message #{ENV['LOG_HANDLER']}")
+            Rails.logger.warn("STDERR_TP_API test_message")
+            Rails.logger.error("STDERR_TP_API test_message")
+          end
+
           raise_unless_primary_instance_exists
           render :json => Insights::API::Common::PaginatedResponseV2.new(
             :base_query => scoped(filtered.where(params_for_list)),

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,7 +60,7 @@ class ApplicationController < ActionController::API
   end
 
   def permitted_params
-    api_doc_definition.all_attributes + [:limit, :offset, :sort_by] + [subcollection_foreign_key]
+    api_doc_definition.all_attributes + [:limit, :offset, :sort_by] + [:test] + [subcollection_foreign_key]
   end
 
   def subcollection_foreign_key

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,7 @@ module TopologicalInventory
     config.autoload_paths << Rails.root.join("lib").to_s
 
     config.log_level = (ENV['RAILS_LOG_LEVEL'] || 'debug').downcase.to_sym
-    Insights::API::Common::Logging.activate(config)
+    Insights::API::Common::Logging.activate(config, "topological_inventory_api")
     # TODO: add an option to disable web_server_metrics
     # TODO: it's almost the same like PrometheusExporter::Middleware but with less data
     Insights::API::Common::Metrics.activate(config, "topological_inventory_api")


### PR DESCRIPTION
This PR replaces `manageiq-loggers` gem with [insights-loggers-ruby](https://github.com/RedHatInsights/insights-loggers-ruby) gem, usage is mentioned in readme of the repo's gem.

it also adds some testing messages and it tests 'insights-api-common' from my branch. (so https://github.com/RedHatInsights/insights-api-common-rails/pull/225 don't need to be merged.)

docker file is also changed to prepend haberdasher to `run_rails_server` command.

### Links

- [x] e2e: https://github.com/RedHatInsights/e2e-deploy/pull/3039
https://issues.redhat.com/browse/RHCLOUD-13925

